### PR TITLE
添加自动打包整合包的流水线

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,36 @@
+name: Modpack export
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  build:
+    runs-on: windows-latest
+    
+    steps:
+    - name: Download source code
+      uses: actions/checkout@v6
+
+    - name: Download packwiz
+      run: |
+        curl --output "packwiz.zip" -L "https://nightly.link/packwiz/packwiz/workflows/go/main/Windows%2064-bit.zip"
+        tar -xf "packwiz.zip"
+        
+    - name: 导出整合包
+      run: |
+        .\packwiz cf export --output client.zip
+        .\packwiz cf export --side server --output serverpack.zip
+
+    - name: Upload modpack (client)
+      uses: actions/upload-artifact@v4
+      with:
+        name: modpack-client
+        path: "client.zip"
+    - name: Upload modpack (server)
+      uses: actions/upload-artifact@v4
+      with:
+        name: modpack-server
+        path: "serverpack.zip"

--- a/.packwizignore
+++ b/.packwizignore
@@ -3,3 +3,4 @@
 /*.xmind
 /serverpack-template/
 /*.lnk
+/.github/


### PR DESCRIPTION
当有改动被push到master分支后自动触发，会通过actions自动打包好服务端和客户端的整合包（无需再手动使用packwiz打包）。